### PR TITLE
Remove Erubis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 ruby '2.7.1'
 
-gem 'erubis'
 gem 'sastrawi'
 gem 'sinatra'
 gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ GEM
   specs:
     backports (3.17.0)
     diff-lcs (1.3)
-    erubis (2.7.0)
     multi_json (1.14.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -45,7 +44,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  erubis
   rack-test
   rspec
   sastrawi


### PR DESCRIPTION
I had a plan to use [Erubis](www.kuwata-lab.com/erubis/) to make eRuby implementation secured. But, this gem isn't used until now. It's better to remove this gem and stick to erb (bundled in Ruby).